### PR TITLE
Fix GitHub spelling

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <body>
   <h1>Nate Fischer</h1>
 
-  <a href="https://github.com/nfischer">Find me on Github!</a>
+  <a href="https://github.com/nfischer">Find me on GitHub!</a>
 
   <h2>Professional work at Google</h2>
   <p>I work on two open source projects professionally: Android and Chromium.</p>
@@ -31,7 +31,7 @@
     <li><a href="framily-tree/">An interactive family tree for my fraternity</a>.</li>
   </ul>
 
-  <h3>Download it from Github</h3>
+  <h3>Download it from GitHub</h3>
   <ul>
     <li><a href="https://github.com/nfischer/satelliteTracker">Satellite Tracker</a>: track the ISS (or other satellites) accurately from anywhere in the world (even without internet connection).</li>
     <li><a href="https://github.com/shelljs/shelljs">ShellJS</a>: portable Unix shell commands for NodeJS. <span class="parenthetical">(a project I joined and maintain)</span></li>


### PR DESCRIPTION
Just fixes two minor typos: `Github` -> `GitHub`